### PR TITLE
Fix dangling pointer in KCBCreateBodyFrame()

### DIFF
--- a/KCBv2/KCBFrames.cpp
+++ b/KCBv2/KCBFrames.cpp
@@ -25,9 +25,8 @@ KINECT_CB HRESULT APIENTRY KCBCreateBodyFrame(_Out_ KCBBodyFrame** ppBodyFrame)
     // do we need to create the buffer
     KCBBodyFrame* pFrame = new KCBBodyFrame();
 
-    IBody* pBodies[BODY_COUNT] = {0};
     pFrame->Count = BODY_COUNT;
-    pFrame->Bodies = pBodies;
+    pFrame->Bodies = new IBody* [BODY_COUNT]();
     pFrame->TimeStamp = 0;
 
     *ppBodyFrame = pFrame;


### PR DESCRIPTION
Hi, there is a dangling pointer in KCBCreateBodyFrame().
It would crash in pBodyFrame->GetAndRefreshBodyData() (KCBv2Lib.cpp#876) when we use KCBGetAllFrameData() to retrieve body frame.
