### PR TITLE
Add a KCBV2_STATIC symbol for static lib compilation

### DIFF
--- a/KCBv2/KCBv2Lib.h
+++ b/KCBv2/KCBv2Lib.h
@@ -24,12 +24,16 @@ See the Apache 2 License for the specific language governing permissions and lim
 #include <Kinect.h>                         // will need $(KINECTSDK20_DIR)inc; in the includes directory for project
 
 #ifdef WIN32
-    #ifdef KCBV2_EXPORTS
-        #define KINECT_CB __declspec(dllexport)
+    #ifdef KCBV2_STATIC
+        #define KINECT_CB
     #else
-        #define KINECT_CB __declspec(dllimport)
-        #pragma comment (lib, "KCBv2")      // add $(KINECTSDK20_DIR)lib\x64 or x86 to the library directory for project
-    #endif // DLL_EXPORTS
+        #ifdef KCBV2_EXPORTS
+            #define KINECT_CB __declspec(dllexport)
+        #else
+            #define KINECT_CB __declspec(dllimport)
+            #pragma comment (lib, "KCBv2")      // add $(KINECTSDK20_DIR)lib\x64 or x86 to the library directory for project
+        #endif // DLL_EXPORTS
+    #endif // !KCBV2_STATIC
 #endif //_WIN32
 
 #ifndef __KCB_HANDLE__

--- a/KCBv2/dllmain.cpp
+++ b/KCBv2/dllmain.cpp
@@ -15,6 +15,7 @@ See the Apache 2 License for the specific language governing permissions and lim
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "stdafx.h"
 
+#ifndef KCBV2_STATIC
 BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID /* lpReserved */)
 {
     switch (ul_reason_for_call)
@@ -27,4 +28,4 @@ BOOL APIENTRY DllMain(HMODULE /* hModule */, DWORD ul_reason_for_call, LPVOID /*
     }
     return TRUE;
 }
-
+#endif


### PR DESCRIPTION
Hi, in order to make deployment easier, we usually use static linking for 3rd party libs when we develop Maya plugins. I think it might be useful for the support of static lib compilation. :)
