### PR TITLE
Fixes for the audio system

### DIFF
--- a/KCBv2/KCBSensor.cpp
+++ b/KCBv2/KCBSensor.cpp
@@ -900,7 +900,7 @@ HRESULT KCBSensor::GetAudioBuffer(ULONG cb, _Out_writes_bytes_to_(cb, *pcbRead) 
         SAFE_RELEASE(pAudioBeam);
     }
 
-    CHECK_HR(hr = m_pAudioStream->Read((void *)cbBuffer, sizeof(cb), pcbRead));
+    CHECK_HR(hr = m_pAudioStream->Read((void *)cbBuffer, cb, pcbRead));
 
     if (*pcbRead > 0)
     {

--- a/KCBv2/KCBv2Lib.cpp
+++ b/KCBv2/KCBv2Lib.cpp
@@ -104,17 +104,27 @@ HRESULT FindAudioDevice(const WCHAR* wsName, IAudioClient** ppClient)
     // Each loop until we find the Kinect USB Audio device
     for (ULONG i = 0; i < count; ++i)
     {
-        CHECK_HR(hr = pCollection->Item(i, &pEndpoint));
+        hr = pCollection->Item(i, &pEndpoint);
+		if (!SUCCEEDED(hr)) {
+			continue;
+		}
 
         // get the property store from the device
-        CHECK_HR(hr = pEndpoint->OpenPropertyStore(STGM_READ, &pProps));
+        hr = pEndpoint->OpenPropertyStore(STGM_READ, &pProps);
+		if (!SUCCEEDED(hr)) {
+			continue;
+		}
 
         // Initialize container for property value.
         PROPVARIANT varName;
         PropVariantInit(&varName);
 
         // Get the endpoint's friendly-name property.
-        CHECK_HR(hr = pProps->GetValue(PKEY_Device_FriendlyName, &varName));
+        hr = pProps->GetValue(PKEY_Device_FriendlyName, &varName);
+
+		if (!SUCCEEDED(hr)) {
+			continue;
+		}
 
         // get the name from the property store
         name = varName.pwszVal;


### PR DESCRIPTION
I found 2 issues with the audio system:
- If something went wrong in the device enumeration loop in FindAudioDevice, all the devices after that would be skipped because CHECK_HR jumped out of the loop. In my case the Kinect audio device would never be found.
- KCBSensor::GetAudioBuffer was ignoring the amount of bytes requested and instead passing the sizeof this value as the amount of bytes to read. This resulted in the same number of bytes (4) being read all the time.
